### PR TITLE
Update blocklist.yaml

### DIFF
--- a/blocklist.yaml
+++ b/blocklist.yaml
@@ -2317,3 +2317,5 @@
   - url: webjup.cc
   - url: index-raydium.web.app
   - url: pumpp-fun.pages.dev
+  - url: claim-jupswap.com
+  - url: gift-jupswap.com


### PR DESCRIPTION
Subject: Phishing Site Impersonating Solana Project – Immediate Action Requested

Domain(s):

https://claim-jupswap.com (redirects to https://gift-jupswap.com)

https://gift-jupswap.com

Description:

The websites listed above are part of an active phishing campaign targeting Solana users. The initial domain (claim-jupswap.com) redirects to gift-jupswap.com, which impersonates a legitimate Solana-related service and attempts to deceive users into entering their 12/24-word seed phrases under the pretense of claiming an airdrop or voucher.